### PR TITLE
[Fix #14] Fix restore backup extraction if CFG->backuptempdir is set

### DIFF
--- a/classes/task/restore_courses.php
+++ b/classes/task/restore_courses.php
@@ -137,6 +137,11 @@ class restore_courses extends \core\task\scheduled_task {
                 $filepacker = get_file_packer('application/vnd.moodle.backup');
                 $foldername = \core\uuid::generate();
                 $temppath = $CFG->dataroot . '/temp/backup/' . $foldername;
+                if(!empty($CFG->backuptempdir) && is_dir($CFG->backuptempdir)) {
+                    // Use the set backuptempdir from config,
+                    // as restore_controller will use it for processing.
+                    $temppath = $CFG->backuptempdir . DIRECTORY_SEPARATOR . $foldername;
+                }
                 if (!$filepacker->extract_to_pathname($file, $temppath)) {
                     // Output error message for cron listing.
                     echo "\n\t" . get_string('skippingunzipfailed', 'local_sandbox', $file) . "\n";


### PR DESCRIPTION
As described in #14, this PR adds logic to change the path if `$CFG->backuptempdir` is set in config.php. 